### PR TITLE
Allow specifying a PVC label selector in values file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: "true"

--- a/charts/bluesky-pds/Chart.yaml
+++ b/charts/bluesky-pds/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluesky-pds/README.md
+++ b/charts/bluesky-pds/README.md
@@ -88,6 +88,7 @@ Once this is done, you should be able to login on https://bsky.app/ using your P
 | pds.dataStorage.mountPath | string | `"/pds"` | Where to mount the PVC. Make sure it matches pds.config.dataDir! |
 | pds.dataStorage.size | string | `"10Gi"` | How large of a PVC to make |
 | pds.dataStorage.storageClass | string | `nil` | Storage class to use. Defaults to the cluster default. |
+| pds.dataStorage.selector | object | `nil` | Selector for the PVC to filter set of available volumes. Defaults to none. |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |

--- a/charts/bluesky-pds/templates/pvc.yaml
+++ b/charts/bluesky-pds/templates/pvc.yaml
@@ -13,3 +13,7 @@ spec:
   {{- if ne .Values.pds.dataStorage.storageClass "" }}
   storageClassName: {{ .Values.pds.dataStorage.storageClass }}
   {{- end }}
+  {{- with .Values.pds.dataStorage.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/bluesky-pds/values.yaml
+++ b/charts/bluesky-pds/values.yaml
@@ -44,6 +44,8 @@ pds:
     mountPath: "/pds"
     # -- Storage class to use. Defaults to the cluster default.
     storageClass: null
+    # -- Selector for persistent disk
+    selector: null
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
# Problem

Its helpful to have a pvc selector available in some cases if the storageClass doesnt provide enough specificity. In my case, I am still using manually provisioned iSCSI PVs until I get a dynamic provisioner setup.

# Changes

I added a `selector` value in a way I've seen implemented in other charts. The default value is null to not interfere with existing deployments.

I also updated the GitHub workflow chart-releaser stage in a separate commit, as it was trying to re-release the latest version of all charts, instead of just the one that was updated.

# Testing

Testing in my cluster looks good, the PVC was able to be bind as expected. 

![{AD7AF6A4-89AE-4A5C-91C0-59054A070AEE}](https://github.com/user-attachments/assets/d73af215-7f42-492f-abc0-6e145961a70e)

I can provide additional testing evidence if desired, the chart is also available from my fork here: https://holysoles.github.io/nerkho-helm-charts/