### PR TITLE
chore(bluesky-pds): update default image to 0.4.103, remove default image.tag override

### DIFF
--- a/charts/bluesky-pds/Chart.yaml
+++ b/charts/bluesky-pds/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.67
+appVersion: 0.4.107

--- a/charts/bluesky-pds/README.md
+++ b/charts/bluesky-pds/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy a [Bluesky PDS](https://github.com/bluesky-social/pds) on Kubernetes.
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.67](https://img.shields.io/badge/AppVersion-0.4.67-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.107](https://img.shields.io/badge/AppVersion-0.4.107-informational?style=flat-square)
 
 ## Installing the Chart
 
@@ -59,7 +59,7 @@ Once this is done, you should be able to login on https://bsky.app/ using your P
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/bluesky-social/pds"` |  |
-| image.tag | string | `"0.4.67"` |  |
+| image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/charts/bluesky-pds/values.yaml
+++ b/charts/bluesky-pds/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: ghcr.io/bluesky-social/pds
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.4.67"
+  tag: ""
 
 pds:
   config:


### PR DESCRIPTION
This PR bumps to the latest Bluesky PDS version, I've been running for a week without issues.

Also removes the value set in Values.yaml for `image.tag`, as it isn't necessary, [the image will default to using the appVersion from the Chart.yaml](https://github.com/Nerkho/helm-charts/blob/main/charts/bluesky-pds/templates/deployment.yaml#L34).