### PR TITLE
Add livenessprobe to values.yaml for tuning

### DIFF
--- a/charts/bluesky-pds/Chart.yaml
+++ b/charts/bluesky-pds/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluesky-pds/templates/deployment.yaml
+++ b/charts/bluesky-pds/templates/deployment.yaml
@@ -84,13 +84,9 @@ spec:
             - name: data
               mountPath: {{ .Values.pds.dataStorage.mountPath }}
           livenessProbe:
-            httpGet:
-              path: /xrpc/_health
-              port: pds-port
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          #readinessProbe:
+          #  { {- toYaml .Values.readinessProbe | nindent 12 } }
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/charts/bluesky-pds/values.yaml
+++ b/charts/bluesky-pds/values.yaml
@@ -114,3 +114,20 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Tunable liveness probe, might be necessary on slower machines that kill slow containers.
+livenessProbe:
+  #failureThreshold: 3
+  #successThreshold: 1
+  #timeoutSeconds: 1
+  #periodSeconds: 10
+  httpGet:
+    path: /xrpc/_health
+    port: pds-port
+    #scheme: HTTP
+
+# TODO: Implement Readiness Probe
+# readinessProbe:
+#   httpGet:
+#     path: /
+#     port: http


### PR DESCRIPTION
I noticed on deployment that k8s was killing my container pretty quickly. Seems like my hardware was too slow. 

Adding configurable livenessprobes should help with that.

I've deployed and tested my changes using my own helm chart. 

https://hub.docker.com/layers/enigodupont/bluesky-pds/0.4.0/images/sha256-2142fc01cbf9ae348667446b238278eb3023b2d01ef968b54f817019d8b71038