### PR TITLE
Redlib: make liveness probe configurable

### DIFF
--- a/charts/redlib/Chart.yaml
+++ b/charts/redlib/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/redlib/templates/deployment.yaml
+++ b/charts/redlib/templates/deployment.yaml
@@ -79,9 +79,7 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}             
           readinessProbe:
             httpGet:
               path: /

--- a/charts/redlib/values.yaml
+++ b/charts/redlib/values.yaml
@@ -86,6 +86,16 @@ ingress:
   #    hosts:
   #      - redlib.exemple.com
 
+#Based on the health check for Docker Compose, see:
+# https://github.com/redlib-org/redlib/blob/main/compose.yaml
+livenessProbe:
+  httpGet:
+    path: /settings
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 60
+  timeoutSeconds: 5
+
 resources:
   {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Hello @Nerkho,

I have observed similar behavior with the redlib chart as described in #8 8. The pod is restarted immediately because the timeout is too short. In addition, restarts also occur when reddit is unavailable. In the Redlib Compose [file](https://github.com/redlib-org/redlib/blob/main/compose.yaml), `/settings` is used as the [target](https://github.com/redlib-org/redlib/blob/3e67694e2b9a4012b259264af5f2b81807dbadf0/compose.yaml#L19). 