### PR TITLE
chore(bluesky-pds): update default image to 0.4.158

### DIFF
--- a/charts/bluesky-pds/Chart.yaml
+++ b/charts/bluesky-pds/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.107
+appVersion: 0.4.158


### PR DESCRIPTION
This PR bumps to the latest Bluesky PDS version, I've been running it for almost a week without issues.

[The changelog can be found here](https://github.com/bluesky-social/atproto/blob/main/packages/pds/CHANGELOG.md#04158), there are a number of small bugfixes included.