### PR TITLE
chore(bluesky-pds): update default image to 0.4.204

### DIFF
--- a/charts/bluesky-pds/Chart.yaml
+++ b/charts/bluesky-pds/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 name: bluesky-pds
 description: A Helm chart to deploy a Bluesky PDS
-
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -11,14 +10,12 @@ description: A Helm chart to deploy a Bluesky PDS
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
-
+version: 0.4.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.158
+appVersion: 0.4.204


### PR DESCRIPTION
Been running a newer version of the bluesky pds image using the chart for over a week and seems stable. Opening a PR to bump the default version.